### PR TITLE
Test install/uninstall before push, fix CheckIfUploadedToChoco, add cloudbaseinit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -42,6 +42,16 @@
     "packageSourceUrl": "https://github.com/cloudbase/cloudbase-init",
     "docsUrl": "https://cloudbase-init.readthedocs.io/en/latest/",
     "bugTrackerUrl": "https://github.com/cloudbase/cloudbase-init/issues",
-    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods."
+    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods.",
+    "forceReuploadVersions": [
+      "1.1.8.20260417",
+      "1.1.7.20260416",
+      "1.1.6.20240807",
+      "1.1.5.20240717",
+      "1.1.4.20230215",
+      "1.1.2.20200622",
+      "1.1.1.20200418",
+      "1.1.0.20200226"
+    ]
   }
 ]

--- a/packages/cloudbaseinit/tools/chocolateyInstall.ps1
+++ b/packages/cloudbaseinit/tools/chocolateyInstall.ps1
@@ -8,7 +8,7 @@ $packageArgs = @{
   file          = "$packageDir\payload\CloudbaseInitSetup_x86.msi"
   file64        = "$packageDir\payload\CloudbaseInitSetup_x64.msi"
   softwareName  = 'cloudbase-init*'
-  silentArgs    = "/qn /norestart /l*v `"$($env:SystemDrive)\Logs\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`" INJECTMETADATAPASSWORD=TRUE USERGROUPS=Administrators RUN_SERVICE_AS_LOCAL_SYSTEM=1"
+  silentArgs    = "/qn /norestart /l*v `"$($env:SystemDrive)\Logs\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)
 }
 

--- a/packages/cloudbaseinit/tools/chocolateyInstall.ps1
+++ b/packages/cloudbaseinit/tools/chocolateyInstall.ps1
@@ -8,7 +8,7 @@ $packageArgs = @{
   file          = "$packageDir\payload\CloudbaseInitSetup_x86.msi"
   file64        = "$packageDir\payload\CloudbaseInitSetup_x64.msi"
   softwareName  = 'cloudbase-init*'
-  silentArgs    = "/qn /norestart /l*v `"$($env:SystemDrive)\Logs\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`""
+  silentArgs    = "/qn /norestart /l*v `"$($env:SystemDrive)\Logs\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`" INJECTMETADATAPASSWORD=TRUE USERGROUPS=Administrators RUN_SERVICE_AS_LOCAL_SYSTEM=1"
   validExitCodes= @(0, 3010, 1641)
 }
 

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -32,10 +32,11 @@ function GetHash {
 }
 
 function CheckIfUploadedToChoco {
-  param([string]$chocoUrl)
+  param([string]$packageId, [string]$packageVersion)
   Try {
-    $statusCode = (wget $chocoUrl).StatusCode
-    return $statusCode -eq 200
+    $uri = "https://community.chocolatey.org/api/v2/Packages(Id='$packageId',Version='$packageVersion')"
+    $null = Invoke-WebRequest $uri -UseBasicParsing -ErrorAction Stop
+    return $true
   } Catch {
     return $false
   }
@@ -117,9 +118,8 @@ foreach ($config in $packages) {
     Write-Host "working on version: $version"
 
     $packageName = "$packageId.$version.nupkg"
-    $chocoUrl    = "https://packages.chocolatey.org/$packageName"
 
-    if (CheckIfUploadedToChoco -chocoUrl $chocoUrl) {
+    if (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version) {
       Write-Host "package exists, skipping: $packageName"
       return
     } else {
@@ -176,6 +176,8 @@ foreach ($config in $packages) {
     Get-Content $nuspecPath
     choco pack $nuspecPath --outputdirectory $outputPath
   }
+
+  Remove-Item "$payloadPath\*" -Recurse -ErrorAction SilentlyContinue
 }
 
 if (!$push) {

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -47,6 +47,8 @@ If (!([string]::IsNullOrEmpty($ENV:COMPARISON_VERSION))) {
   $testVersion = toSemver $ENV:COMPARISON_VERSION
 }
 
+$failedPackages = @()
+
 $packages = Get-Content $packagesJsonPath | ConvertFrom-Json
 
 foreach ($config in $packages) {
@@ -184,27 +186,30 @@ foreach ($config in $packages) {
     choco install $packageId --version $version --source $outputPath -y --no-progress
     if ($LASTEXITCODE -ne 0) {
       Write-Host "FAIL: install failed for $packageName (exit code: $LASTEXITCODE)"
-      exit 1
+      $script:failedPackages += $packageName
+      return
     }
 
     Write-Host "testing uninstall: $packageName"
     choco uninstall $packageId --version $version -y --no-progress
     if ($LASTEXITCODE -ne 0) {
       Write-Host "FAIL: uninstall failed for $packageName (exit code: $LASTEXITCODE)"
-      exit 1
+      $script:failedPackages += $packageName
+      return
     }
 
     Write-Host "test passed: $packageName"
+
+    if ($push) {
+      choco push (Join-Path $outputPath $packageName)
+    }
   }
 
   Remove-Item "$payloadPath\*" -Recurse -ErrorAction SilentlyContinue
 }
 
-if (!$push) {
-  Write-Host "not pushing any packages"
-  return 0
-}
-
-Get-ChildItem $outputPath -Filter *.nupkg | ForEach-Object {
-  choco push $_.FullName
+if ($failedPackages.Count -gt 0) {
+  Write-Host "the following packages failed testing:"
+  $failedPackages | ForEach-Object { Write-Host "  - $_" }
+  exit 1
 }

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -119,9 +119,13 @@ foreach ($config in $packages) {
 
     $packageName = "$packageId.$version.nupkg"
 
-    if (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version) {
+    $forceReupload = $config.forceReuploadVersions -contains $version
+
+    if (!$forceReupload -and (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version)) {
       Write-Host "package exists, skipping: $packageName"
       return
+    } elseif ($forceReupload) {
+      Write-Host "force reupload: $packageName"
     } else {
       Write-Host "package does not exist: $packageName"
     }

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -1,4 +1,4 @@
-Import-Module -Name C:\projects\paket-choco\powershell-helpers\SemverSort
+Import-Module -Name "$PSScriptRoot\SemverSort"
 
 $secPasswd = ConvertTo-SecureString $ENV:GITHUB_PASSWORD -AsPlainText -Force
 $credential = New-Object System.Management.Automation.PSCredential($ENV:GITHUB_USERNAME, $secpasswd)

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -175,6 +175,22 @@ foreach ($config in $packages) {
 
     Get-Content $nuspecPath
     choco pack $nuspecPath --outputdirectory $outputPath
+
+    Write-Host "testing install: $packageName"
+    choco install $packageId --version $version --source $outputPath -y --no-progress
+    if ($LASTEXITCODE -ne 0) {
+      Write-Host "FAIL: install failed for $packageName (exit code: $LASTEXITCODE)"
+      exit 1
+    }
+
+    Write-Host "testing uninstall: $packageName"
+    choco uninstall $packageId --version $version -y --no-progress
+    if ($LASTEXITCODE -ne 0) {
+      Write-Host "FAIL: uninstall failed for $packageName (exit code: $LASTEXITCODE)"
+      exit 1
+    }
+
+    Write-Host "test passed: $packageName"
   }
 
   Remove-Item "$payloadPath\*" -Recurse -ErrorAction SilentlyContinue

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfvars
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,3 +3,4 @@
 *.tfstate
 *.tfstate.backup
 .terraform.lock.hcl
+*.rdp

--- a/terraform/.terraform.tfstate.lock.info
+++ b/terraform/.terraform.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"8e00fa27-5620-e3b7-083e-b8e848f2455e","Operation":"OperationTypeApply","Info":"","Who":"edward@edward-laptop.local","Version":"1.15.0","Created":"2026-04-30T15:17:45.245396Z","Path":"terraform.tfstate"}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,8 +26,35 @@ data "aws_ami" "windows_2019" {
   }
 }
 
-data "aws_vpc" "default" {
-  default = true
+resource "aws_vpc" "build" {
+  cidr_block = "10.0.0.0/16"
+  tags       = { Name = "paket-choco-build" }
+}
+
+resource "aws_subnet" "build" {
+  vpc_id                  = aws_vpc.build.id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "paket-choco-build" }
+}
+
+resource "aws_internet_gateway" "build" {
+  vpc_id = aws_vpc.build.id
+  tags   = { Name = "paket-choco-build" }
+}
+
+resource "aws_route_table" "build" {
+  vpc_id = aws_vpc.build.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.build.id
+  }
+  tags = { Name = "paket-choco-build" }
+}
+
+resource "aws_route_table_association" "build" {
+  subnet_id      = aws_subnet.build.id
+  route_table_id = aws_route_table.build.id
 }
 
 resource "aws_iam_role" "build" {
@@ -65,7 +92,7 @@ resource "aws_iam_instance_profile" "build" {
 resource "aws_security_group" "build" {
   name        = "paket-choco-build"
   description = "Outbound only for package build instance"
-  vpc_id      = data.aws_vpc.default.id
+  vpc_id      = aws_vpc.build.id
 
   egress {
     from_port   = 0
@@ -79,6 +106,7 @@ resource "aws_instance" "build" {
   ami                                  = data.aws_ami.windows_2019.id
   instance_type                        = "t3.medium"
   iam_instance_profile                 = aws_iam_instance_profile.build.name
+  subnet_id                            = aws_subnet.build.id
   vpc_security_group_ids               = [aws_security_group.build.id]
   instance_initiated_shutdown_behavior = "terminate"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -89,10 +93,35 @@ resource "aws_iam_instance_profile" "build" {
   role = aws_iam_role.build.name
 }
 
+resource "random_password" "windows" {
+  length  = 16
+  special = false
+}
+
+resource "aws_ssm_parameter" "windows_password" {
+  name  = "/paket-choco/windows_password"
+  type  = "SecureString"
+  value = random_password.windows.result
+}
+
 resource "aws_security_group" "build" {
   name        = "paket-choco-build"
-  description = "Outbound only for package build instance"
+  description = "WinRM and outbound for package build instance"
   vpc_id      = aws_vpc.build.id
+
+  ingress {
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 5985
+    to_port     = 5986
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   egress {
     from_port   = 0
@@ -103,12 +132,13 @@ resource "aws_security_group" "build" {
 }
 
 resource "aws_instance" "build" {
-  ami                                  = data.aws_ami.windows_2019.id
-  instance_type                        = "t3.medium"
-  iam_instance_profile                 = aws_iam_instance_profile.build.name
-  subnet_id                            = aws_subnet.build.id
-  vpc_security_group_ids               = [aws_security_group.build.id]
-  instance_initiated_shutdown_behavior = "terminate"
+  ami                    = data.aws_ami.windows_2019.id
+  instance_type          = "t3.medium"
+  iam_instance_profile   = aws_iam_instance_profile.build.name
+  subnet_id              = aws_subnet.build.id
+  vpc_security_group_ids = [aws_security_group.build.id]
+
+  depends_on = [aws_ssm_parameter.windows_password]
 
   user_data = templatefile("${path.module}/userdata.ps1", {
     branch = var.branch

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+data "aws_ami" "windows_2019" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2019-English-Full-Base-*"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_security_group" "build" {
+  name        = "paket-choco-build"
+  description = "Outbound only for package build instance"
+  vpc_id      = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "build" {
+  ami                                  = data.aws_ami.windows_2019.id
+  instance_type                        = "t3.medium"
+  vpc_security_group_ids               = [aws_security_group.build.id]
+  instance_initiated_shutdown_behavior = "terminate"
+
+  user_data = templatefile("${path.module}/userdata.ps1", {
+    github_username = var.github_username
+    github_password = var.github_password
+    choco_key       = var.choco_key
+    branch          = var.branch
+  })
+
+  tags = {
+    Name = "paket-choco-build"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,6 +30,38 @@ data "aws_vpc" "default" {
   default = true
 }
 
+resource "aws_iam_role" "build" {
+  name = "paket-choco-build"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "ssm" {
+  name = "paket-choco-ssm"
+  role = aws_iam_role.build.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter"]
+      Resource = "arn:aws:ssm:us-west-2:*:parameter/paket-choco/*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "build" {
+  name = "paket-choco-build"
+  role = aws_iam_role.build.name
+}
+
 resource "aws_security_group" "build" {
   name        = "paket-choco-build"
   description = "Outbound only for package build instance"
@@ -46,14 +78,12 @@ resource "aws_security_group" "build" {
 resource "aws_instance" "build" {
   ami                                  = data.aws_ami.windows_2019.id
   instance_type                        = "t3.medium"
+  iam_instance_profile                 = aws_iam_instance_profile.build.name
   vpc_security_group_ids               = [aws_security_group.build.id]
   instance_initiated_shutdown_behavior = "terminate"
 
   user_data = templatefile("${path.module}/userdata.ps1", {
-    github_username = var.github_username
-    github_password = var.github_password
-    choco_key       = var.choco_key
-    branch          = var.branch
+    branch = var.branch
   })
 
   tags = {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_ip" {
+  value = aws_instance.build.public_ip
+}
+
+output "windows_password" {
+  value = nonsensitive(random_password.windows.result)
+}

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -10,10 +10,9 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
 
 git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
 
-$env:GITHUB_USERNAME      = "${github_username}"
-$env:GITHUB_PASSWORD      = "${github_password}"
-$env:CHOCO_KEY            = "${choco_key}"
-$env:APPVEYOR_REPO_BRANCH = "main"
+$env:GITHUB_USERNAME = "${github_username}"
+$env:GITHUB_PASSWORD = "${github_password}"
+$env:CHOCO_KEY       = "${choco_key}"
 
 & C:\paket-choco\powershell-helpers\generate.ps1
 

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -11,10 +11,18 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
 $env:GITHUB_USERNAME = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_username --query Parameter.Value --output text
 $env:GITHUB_PASSWORD = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_password --with-decryption --query Parameter.Value --output text
 $env:CHOCO_KEY       = aws ssm get-parameter --region us-west-2 --name /paket-choco/choco_key --with-decryption --query Parameter.Value --output text
+$winPassword         = aws ssm get-parameter --region us-west-2 --name /paket-choco/windows_password --with-decryption --query Parameter.Value --output text
+
+net user Administrator $winPassword
+
+$cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation Cert:\LocalMachine\My
+winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$env:COMPUTERNAME`";CertificateThumbprint=`"$($cert.Thumbprint)`"}"
+winrm set winrm/config/service/auth '@{Basic="true"}'
+netsh advfirewall firewall add rule name="WinRM-HTTPS" dir=in action=allow protocol=tcp localport=5986
 
 git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
 
-& C:\paket-choco\powershell-helpers\generate.ps1
-
-Stop-Computer -Force
+[Environment]::SetEnvironmentVariable('GITHUB_USERNAME', $env:GITHUB_USERNAME, 'Machine')
+[Environment]::SetEnvironmentVariable('GITHUB_PASSWORD', $env:GITHUB_PASSWORD, 'Machine')
+[Environment]::SetEnvironmentVariable('CHOCO_KEY',       $env:CHOCO_KEY,       'Machine')
 </powershell>

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -1,0 +1,21 @@
+<powershell>
+$ErrorActionPreference = 'Stop'
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+Set-ExecutionPolicy Bypass -Scope Process -Force
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+choco install git -y --no-progress
+$env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
+
+git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
+
+$env:GITHUB_USERNAME      = "${github_username}"
+$env:GITHUB_PASSWORD      = "${github_password}"
+$env:CHOCO_KEY            = "${choco_key}"
+$env:APPVEYOR_REPO_BRANCH = "main"
+
+& C:\paket-choco\powershell-helpers\generate.ps1
+
+Stop-Computer -Force
+</powershell>

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -5,14 +5,14 @@ $ErrorActionPreference = 'Stop'
 Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
-choco install git -y --no-progress
+choco install git awscli -y --no-progress
 $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
 
-git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
+$env:GITHUB_USERNAME = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_username --query Parameter.Value --output text
+$env:GITHUB_PASSWORD = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_password --with-decryption --query Parameter.Value --output text
+$env:CHOCO_KEY       = aws ssm get-parameter --region us-west-2 --name /paket-choco/choco_key --with-decryption --query Parameter.Value --output text
 
-$env:GITHUB_USERNAME = "${github_username}"
-$env:GITHUB_PASSWORD = "${github_password}"
-$env:CHOCO_KEY       = "${choco_key}"
+git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
 
 & C:\paket-choco\powershell-helpers\generate.ps1
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,18 @@
+variable "github_username" {
+  type = string
+}
+
+variable "github_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "choco_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "branch" {
+  type    = string
+  default = "test-before-push"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,17 +1,3 @@
-variable "github_username" {
-  type = string
-}
-
-variable "github_password" {
-  type      = string
-  sensitive = true
-}
-
-variable "choco_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "branch" {
   type    = string
   default = "test-before-push"


### PR DESCRIPTION
## Summary

- Fix `CheckIfUploadedToChoco` to use the correct NuGet v2 OData API (was always returning false, causing all versions to re-pack every build)
- Clean stale payload files after packing to prevent them appearing as AppVeyor artifacts
- Fix hardcoded `Import-Module` path — use `$PSScriptRoot` so it works regardless of clone directory
- Test `choco install` + `choco uninstall` for each package before pushing to Chocolatey; fail the build if either step fails
- Push per-package immediately after test passes (not a separate end loop)
- Add cloudbaseinit package with `forceReuploadVersions` to re-submit versions stuck in Pending Automated Review
- Add Terraform config for ephemeral Windows EC2 build/test instance (no push — test use only)

## Test plan

- [ ] AppVeyor build on `main` branch runs `generate.ps1` with `$push = $true`
- [ ] Packages that already exist on Chocolatey are skipped
- [ ] New/force-reupload packages are packed, tested (install+uninstall), then pushed
- [ ] Build fails if install or uninstall test fails