### PR TITLE
Remove tracked Terraform state lock file

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -4,3 +4,4 @@
 *.tfstate.backup
 .terraform.lock.hcl
 *.rdp
+*.lock.info

--- a/terraform/.terraform.tfstate.lock.info
+++ b/terraform/.terraform.tfstate.lock.info
@@ -1,1 +1,0 @@
-{"ID":"8e00fa27-5620-e3b7-083e-b8e848f2455e","Operation":"OperationTypeApply","Info":"","Who":"edward@edward-laptop.local","Version":"1.15.0","Created":"2026-04-30T15:17:45.245396Z","Path":"terraform.tfstate"}


### PR DESCRIPTION
Deletes the accidentally-committed `.terraform.tfstate.lock.info` and adds `*.lock.info` to the Terraform gitignore.