### PR TITLE
Stop cloudbase-init service before uninstalling to prevent hang

### DIFF
--- a/packages/cloudbaseinit/tools/chocolateyUninstall.ps1
+++ b/packages/cloudbaseinit/tools/chocolateyUninstall.ps1
@@ -7,6 +7,12 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1605, 1614, 1641)
 }
 
+$svc = Get-Service -Name 'cloudbase-init' -ErrorAction SilentlyContinue
+if ($svc -and $svc.Status -ne 'Stopped') {
+  Stop-Service -Name 'cloudbase-init' -Force -ErrorAction SilentlyContinue
+  $svc.WaitForStatus('Stopped', [TimeSpan]::FromMinutes(2))
+}
+
 $uninstalled = $false
 [array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
 


### PR DESCRIPTION
The choco-bot uninstall was hanging because msiexec waits for the cloudbase-init service to stop, and the service hangs in a non-cloud environment. This stops and waits for the service to reach `Stopped` before invoking msiexec.