### PR TITLE
Re-add forceReuploadVersions, remove stale .version artifact path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,4 @@ artifacts:
     name: nupkg
   - path: '**\*.nuspec'
     name: nuspec
-  - path: '**\.version'
-    name: version
 

--- a/packages.json
+++ b/packages.json
@@ -42,6 +42,16 @@
     "packageSourceUrl": "https://github.com/cloudbase/cloudbase-init",
     "docsUrl": "https://cloudbase-init.readthedocs.io/en/latest/",
     "bugTrackerUrl": "https://github.com/cloudbase/cloudbase-init/issues",
-    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods."
+    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods.",
+    "forceReuploadVersions": [
+      "1.1.8.20260417",
+      "1.1.7.20260416",
+      "1.1.6.20240807",
+      "1.1.5.20240717",
+      "1.1.4.20230215",
+      "1.1.2.20200622",
+      "1.1.1.20200418",
+      "1.1.0.20200226"
+    ]
   }
 ]


### PR DESCRIPTION
- Removes the stale `**\.version` artifact path from appveyor.yml (from the old script, never created by generate.ps1)
- Re-adds `forceReuploadVersions` for all 8 cloudbaseinit versions to re-push them with the fixed uninstall script