### PR TITLE
Delete lib folder on uninstall, build only on main, match choco-bot env

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,9 @@
 version: 1.0.{build}
+
+branches:
+  only:
+    - main
+
 build_script:
   - ps: 'powershell-helpers/generate.ps1'
 

--- a/packages/cloudbaseinit/tools/chocolateyUninstall.ps1
+++ b/packages/cloudbaseinit/tools/chocolateyUninstall.ps1
@@ -35,3 +35,5 @@ if ($key.Count -eq 1) {
   Write-Warning "Please alert package maintainer the following keys were matched:"
   $key | % {Write-Warning "- $($_.DisplayName)"}
 }
+
+Remove-Item "$env:ChocolateyInstall\lib\$env:ChocolateyPackageName" -Recurse -Force -ErrorAction SilentlyContinue

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -1,11 +1,34 @@
 <powershell>
 $ErrorActionPreference = 'Stop'
+
+winrm quickconfig -force
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in action=allow protocol=tcp localport=5985
+
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 choco install git awscli -y --no-progress
+
+# Match choco-bot environment (chocolatey-test-environment)
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}' -Name 'IsInstalled' -Value 0 -Force
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}' -Name 'IsInstalled' -Value 0 -Force
+New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main' -Name 'DisableFirstRunCustomize' -Value 1 -PropertyType DWord -Force | Out-Null
+Set-Service -Name wuauserv -StartupType Manual
+
+choco feature enable  -n autouninstaller
+choco feature enable  -n allowGlobalConfirmation
+choco feature enable  -n logEnvironmentValues
+choco feature disable -n showDownloadProgress
+
+choco install kb2919442 --version 1.0.20160915 --skip-powershell -y
+choco install kb2919355 --version 1.0.20160915 --skip-powershell -y
+choco install kb2999226 --version 1.0.20181019 --skip-powershell -y
+choco install kb3035131 --version 1.0.3         --skip-powershell -y
+choco install kb3118401 --version 1.0.5         --skip-powershell -y
 $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
 
 $env:GITHUB_USERNAME = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_username --query Parameter.Value --output text
@@ -14,11 +37,6 @@ $env:CHOCO_KEY       = aws ssm get-parameter --region us-west-2 --name /paket-ch
 $winPassword         = aws ssm get-parameter --region us-west-2 --name /paket-choco/windows_password --with-decryption --query Parameter.Value --output text
 
 net user Administrator $winPassword
-
-$cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation Cert:\LocalMachine\My
-winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$env:COMPUTERNAME`";CertificateThumbprint=`"$($cert.Thumbprint)`"}"
-winrm set winrm/config/service/auth '@{Basic="true"}'
-netsh advfirewall firewall add rule name="WinRM-HTTPS" dir=in action=allow protocol=tcp localport=5986
 
 git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
 


### PR DESCRIPTION
- chocolateyUninstall.ps1: remove the lib folder after uninstall so reinstalls don't fail on locked files
- appveyor.yml: only build on main branch
- terraform/userdata.ps1: configure WinRM HTTP first, remove SSL setup, add choco-bot environment parity (IE ESC, Windows Update manual, choco features, KB packages)