### PR TITLE
Fix uninstall cleanup, env parity, remove force reupload, add PR validation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,19 @@
 version: 1.0.{build}
 
-branches:
-  only:
-    - main
+for:
+  - branches:
+      only:
+        - main
+    build_script:
+      - ps: 'powershell-helpers/generate.ps1'
+    artifacts:
+      - path: '**\*.nupkg'
+        name: nupkg
+      - path: '**\*.nuspec'
+        name: nuspec
 
-build_script:
-  - ps: 'powershell-helpers/generate.ps1'
-
-artifacts:
-  - path: '**\*.nupkg'
-    name: nupkg
-  - path: '**\*.nuspec'
-    name: nuspec
-
+  - branches:
+      except:
+        - main
+    build_script:
+      - ps: 'powershell-helpers/validate.ps1'

--- a/packages.json
+++ b/packages.json
@@ -42,16 +42,6 @@
     "packageSourceUrl": "https://github.com/cloudbase/cloudbase-init",
     "docsUrl": "https://cloudbase-init.readthedocs.io/en/latest/",
     "bugTrackerUrl": "https://github.com/cloudbase/cloudbase-init/issues",
-    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods.",
-    "forceReuploadVersions": [
-      "1.1.8.20260417",
-      "1.1.7.20260416",
-      "1.1.6.20240807",
-      "1.1.5.20240717",
-      "1.1.4.20230215",
-      "1.1.2.20200622",
-      "1.1.1.20200418",
-      "1.1.0.20200226"
-    ]
+    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods."
   }
 ]

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -121,16 +121,12 @@ foreach ($config in $packages) {
 
     $packageName = "$packageId.$version.nupkg"
 
-    $forceReupload = $config.forceReuploadVersions -contains $version
-
-    if (!$forceReupload -and (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version)) {
+    if (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version) {
       Write-Host "package exists, skipping: $packageName"
       return
-    } elseif ($forceReupload) {
-      Write-Host "force reupload: $packageName"
-    } else {
-      Write-Host "package does not exist: $packageName"
     }
+
+    Write-Host "package does not exist: $packageName"
 
     Remove-Item "$payloadPath\*" -Recurse -ErrorAction SilentlyContinue
 

--- a/powershell-helpers/validate.ps1
+++ b/powershell-helpers/validate.ps1
@@ -1,0 +1,66 @@
+$packagesJsonPath = Join-Path $PSScriptRoot '..\packages.json'
+$nuspecTemplate   = Join-Path $PSScriptRoot '..\packages\package.nuspec'
+$toolsDir         = Join-Path $PSScriptRoot '..\packages'
+
+$errors = @()
+
+# Validate packages.json
+try {
+  $packages = Get-Content $packagesJsonPath -Raw | ConvertFrom-Json
+  Write-Host "packages.json: valid JSON ($($packages.Count) packages)"
+} catch {
+  $errors += "packages.json: invalid JSON - $_"
+}
+
+$requiredFields = @('packageId','githubOrg','githubRepo','checksumType','versionFormat',
+                    'title','authors','owners','licenseUrl','iconUrl','tags',
+                    'packageSourceUrl','docsUrl','bugTrackerUrl','verificationHeader')
+
+foreach ($pkg in $packages) {
+  foreach ($field in $requiredFields) {
+    if ([string]::IsNullOrEmpty($pkg.$field)) {
+      $errors += "$($pkg.packageId): missing required field '$field'"
+    }
+  }
+  Write-Host "$($pkg.packageId): required fields OK"
+}
+
+# Validate nuspec template
+try {
+  [xml](Get-Content $nuspecTemplate) | Out-Null
+  Write-Host "package.nuspec: valid XML"
+} catch {
+  $errors += "package.nuspec: invalid XML - $_"
+}
+
+# Validate PowerShell script syntax
+Get-ChildItem $PSScriptRoot -Filter '*.ps1' | ForEach-Object {
+  $ast = $null
+  $parseErrors = $null
+  [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$ast, [ref]$parseErrors) | Out-Null
+  if ($parseErrors.Count -gt 0) {
+    $parseErrors | ForEach-Object { $errors += "$($_.File): $_" }
+  } else {
+    Write-Host "$($_.Name): syntax OK"
+  }
+}
+
+# Validate install/uninstall scripts exist per package
+foreach ($pkg in $packages) {
+  $toolsPkg = Join-Path $toolsDir "$($pkg.packageId)\tools"
+  foreach ($script in @('chocolateyInstall.ps1', 'chocolateyUninstall.ps1', 'LICENSE.txt')) {
+    $path = Join-Path $toolsPkg $script
+    if (!(Test-Path $path)) {
+      $errors += "$($pkg.packageId): missing $script"
+    }
+  }
+  Write-Host "$($pkg.packageId): tool files OK"
+}
+
+if ($errors.Count -gt 0) {
+  Write-Host "`nValidation failed:"
+  $errors | ForEach-Object { Write-Host "  - $_" }
+  exit 1
+}
+
+Write-Host "`nAll validations passed."

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,7 +141,8 @@ resource "aws_instance" "build" {
   depends_on = [aws_ssm_parameter.windows_password]
 
   user_data = templatefile("${path.module}/userdata.ps1", {
-    branch = var.branch
+    branch           = var.branch
+    windows_password = random_password.windows.result
   })
 
   tags = {

--- a/terraform/userdata.ps1
+++ b/terraform/userdata.ps1
@@ -1,6 +1,8 @@
 <powershell>
 $ErrorActionPreference = 'Stop'
 
+net user Administrator '${windows_password}'
+
 winrm quickconfig -force
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
@@ -34,9 +36,6 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
 $env:GITHUB_USERNAME = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_username --query Parameter.Value --output text
 $env:GITHUB_PASSWORD = aws ssm get-parameter --region us-west-2 --name /paket-choco/github_password --with-decryption --query Parameter.Value --output text
 $env:CHOCO_KEY       = aws ssm get-parameter --region us-west-2 --name /paket-choco/choco_key --with-decryption --query Parameter.Value --output text
-$winPassword         = aws ssm get-parameter --region us-west-2 --name /paket-choco/windows_password --with-decryption --query Parameter.Value --output text
-
-net user Administrator $winPassword
 
 git clone --branch ${branch} https://github.com/johnypony3/paket-choco.git C:\paket-choco
 


### PR DESCRIPTION
## Summary
- Fix cloudbaseinit uninstall to delete the lib folder and stop the service before uninstalling
- Match choco-bot test environment (Active Setup registry keys, IE first-run, Windows Update set to manual)
- Pass Windows admin password via Terraform templatefile instead of fetching from SSM at runtime
- Remove `forceReuploadVersions` from `packages.json` and `generate.ps1` — all versions have been re-uploaded and verified
- Split `appveyor.yml`: full build+push on `main`, validation-only job (`validate.ps1`) on all other branches/PRs

## Test plan
- [ ] Install/uninstall tested for all 8 cloudbaseinit versions (1.1.0–1.1.8) on a fresh EC2 instance — all passed
- [ ] Validate CI splits correctly: non-main branches should trigger `validate.ps1`, `main` triggers `generate.ps1`
- [ ] Confirm no packages are re-pushed unnecessarily after removing `forceReuploadVersions`