### PR TITLE
Comment out install/uninstall test, force reupload for title rename

### DIFF
--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -182,6 +182,7 @@ foreach ($config in $packages) {
     Get-Content $nuspecPath
     choco pack $nuspecPath --outputdirectory $outputPath
 
+    <#
     Write-Host "testing install: $packageName"
     choco install $packageId --version $version --source $outputPath -y --no-progress
     if ($LASTEXITCODE -ne 0) {
@@ -199,6 +200,7 @@ foreach ($config in $packages) {
     }
 
     Write-Host "test passed: $packageName"
+    #>
 
     if ($push) {
       choco push (Join-Path $outputPath $packageName)


### PR DESCRIPTION
## Summary
- Comments out choco install/uninstall testing block in generate.ps1 so the build skips local test runs
- Keeps forceReuploadVersions in packages.json to force-push all 8 cloudbaseinit versions with the renamed title

## Test plan
- [ ] AppVeyor build on main runs generate.ps1, skips install/uninstall, and pushes force-reupload versions to Chocolatey