### PR TITLE
Remove forceReuploadVersions, restore install/uninstall test

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -42,16 +42,6 @@
     "packageSourceUrl": "https://github.com/cloudbase/cloudbase-init",
     "docsUrl": "https://cloudbase-init.readthedocs.io/en/latest/",
     "bugTrackerUrl": "https://github.com/cloudbase/cloudbase-init/issues",
-    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods.",
-    "forceReuploadVersions": [
-      "1.1.8.20260417",
-      "1.1.7.20260416",
-      "1.1.6.20240807",
-      "1.1.5.20240717",
-      "1.1.4.20230215",
-      "1.1.2.20200622",
-      "1.1.1.20200418",
-      "1.1.0.20200226"
-    ]
+    "verificationHeader": "VERIFICATION\nVerification is intended to assist the Chocolatey moderators and community\nin verifying that this package's contents are trustworthy.\n\nThe embedded software have been downloaded from the listed download\nlocation on <https://github.com/cloudbase/cloudbase-init/releases>\nand can be verified by doing the following:\n\n1. Packaged assets are downloaded from the github release url above, for the\n  specific release which matches the package version.\n2. Install/Uninstall scripts install/uninstall the MSI silently using\n  chocolatey `Install-ChocolateyInstallPackage` / `Uninstall-ChocolateyPackage` methods."
   }
 ]

--- a/powershell-helpers/generate.ps1
+++ b/powershell-helpers/generate.ps1
@@ -121,13 +121,9 @@ foreach ($config in $packages) {
 
     $packageName = "$packageId.$version.nupkg"
 
-    $forceReupload = $config.forceReuploadVersions -contains $version
-
-    if (!$forceReupload -and (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version)) {
+    if (CheckIfUploadedToChoco -packageId $packageId -packageVersion $version) {
       Write-Host "package exists, skipping: $packageName"
       return
-    } elseif ($forceReupload) {
-      Write-Host "force reupload: $packageName"
     } else {
       Write-Host "package does not exist: $packageName"
     }
@@ -182,7 +178,6 @@ foreach ($config in $packages) {
     Get-Content $nuspecPath
     choco pack $nuspecPath --outputdirectory $outputPath
 
-    <#
     Write-Host "testing install: $packageName"
     choco install $packageId --version $version --source $outputPath -y --no-progress
     if ($LASTEXITCODE -ne 0) {
@@ -200,7 +195,6 @@ foreach ($config in $packages) {
     }
 
     Write-Host "test passed: $packageName"
-    #>
 
     if ($push) {
       choco push (Join-Path $outputPath $packageName)


### PR DESCRIPTION
## Summary
- Removes forceReuploadVersions from packages.json and the related logic from generate.ps1
- Restores the install/uninstall test block that was temporarily commented out

## Test plan
- [ ] AppVeyor build on main runs normally, skipping already-published versions